### PR TITLE
fix build error

### DIFF
--- a/ext/ruby_krb5_auth.c
+++ b/ext/ruby_krb5_auth.c
@@ -24,6 +24,7 @@
 #include <krb5.h>
 #include <stdio.h>
 #include <strings.h>
+#include <com_err.h>
 
 static VALUE mKerberos;
 static VALUE cKrb5;


### PR DESCRIPTION
the build fails on my system due to error_message not being found. fix this by including com_err.h